### PR TITLE
remove old babel to resolve npm error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -69,7 +69,6 @@ export const decorateFooter = (Footer, { React, PropTypes }) => {
     }
 
     async componentDidMount() {
-      this.props.refreshPrice();
       setInterval(async () => {
         this.props.refreshPrice();
       }, 60000);

--- a/lib/index.js
+++ b/lib/index.js
@@ -69,6 +69,7 @@ export const decorateFooter = (Footer, { React, PropTypes }) => {
     }
 
     async componentDidMount() {
+      this.props.refreshPrice();
       setInterval(async () => {
         this.props.refreshPrice();
       }, 60000);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bpanel/price-widget",
-  "version": "0.0.3",
+  "version": "0.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -189,6 +189,16 @@
           "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
           "dev": true
         }
+      }
+    },
+    "@bpanel/price": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@bpanel/price/-/price-0.0.4.tgz",
+      "integrity": "sha512-PALY7f4ZZY207kCSf6GUCbgt903WFKlkT+DfDt56Ycoh0mL/EspRkmVFeMUU/q+xs4i9cRWToMpXHpG6Vb/Kpw==",
+      "requires": {
+        "babel-cli": "^6.26.0",
+        "babel-plugin-transform-runtime": "^6.23.0",
+        "bcurl": "github:pinheadmz/bcurl#e36bf6128f85fefc6404ba51f55c4b1518108c64"
       }
     },
     "acorn": {
@@ -385,11 +395,6 @@
       "requires": {
         "ast-types-flow": "0.0.7"
       }
-    },
-    "babel": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel/-/babel-6.23.0.tgz",
-      "integrity": "sha1-0NHn2APpdHZb7qMjLU4VPA77kPQ="
     },
     "babel-cli": {
       "version": "6.26.0",
@@ -1275,6 +1280,15 @@
       "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
       "dev": true
     },
+    "bcurl": {
+      "version": "github:pinheadmz/bcurl#e36bf6128f85fefc6404ba51f55c4b1518108c64",
+      "from": "github:pinheadmz/bcurl#bpanel-dev",
+      "requires": {
+        "brq": "github:pinheadmz/brq#0fa13642c3f3c80fa0187f57ede995e0049253df",
+        "bsert": "~0.0.5",
+        "bsock": "~0.1.4"
+      }
+    },
     "binary-extensions": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
@@ -1392,6 +1406,26 @@
       "requires": {
         "caniuse-lite": "^1.0.30000844",
         "electron-to-chromium": "^1.3.47"
+      }
+    },
+    "brq": {
+      "version": "github:pinheadmz/brq#0fa13642c3f3c80fa0187f57ede995e0049253df",
+      "from": "github:pinheadmz/brq#patch-1",
+      "requires": {
+        "bsert": "~0.0.5"
+      }
+    },
+    "bsert": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.7.tgz",
+      "integrity": "sha512-m/DKdJbnoviiE6f+I2/Kl0ESQoVSfYv1xYczVItrPyzRrMS0VXebRzzcAJ0ZusyBJbofND8X9RGHzvQoMpnf+g=="
+    },
+    "bsock": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/bsock/-/bsock-0.1.4.tgz",
+      "integrity": "sha512-3hfPScf58kC13udMqXL/GiBubUOmwwMaTljIY8xJI0pO2uOmAaDyBCqT/PiteXRHHC1lDinK2wkFayc4xX92Wg==",
+      "requires": {
+        "bsert": "~0.0.5"
       }
     },
     "buffer": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "repository": "git://github.com/bpanel-org/price-widget.git",
   "dependencies": {
     "@bpanel/price": "0.0.4",
-    "babel": "^6.23.0",
     "babel-cli": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.23.0"
   },


### PR DESCRIPTION
npm threw an error because it saw an old version of `babel` when it needed `babel-cli`. Once this gets merged in we should be good to publish!